### PR TITLE
Fix mid-combat enemy spawns desyncing in multiplayer

### DIFF
--- a/src/WOTRMultiplayer/HarmonyPatches/RandomIdGeneration/EntitiesIdsPatches.cs
+++ b/src/WOTRMultiplayer/HarmonyPatches/RandomIdGeneration/EntitiesIdsPatches.cs
@@ -173,6 +173,7 @@ namespace WOTRMultiplayer.HarmonyPatches.RandomIdGeneration
             {
                 new(OpCodes.Ldarg_1),
                 new(OpCodes.Ldarg_2),
+                new(OpCodes.Ldarg_3),
                 new(OpCodes.Call, replaceWith),
             };
             return PatchPlayerIdGeneration(target, instructions, newInstructions);
@@ -439,7 +440,7 @@ namespace WOTRMultiplayer.HarmonyPatches.RandomIdGeneration
             }
         }
 
-        private static string GetNewUnitUniqueId(BlueprintUnit unit, UnitEntityView prefab)
+        private static string GetNewUnitUniqueId(BlueprintUnit unit, UnitEntityView prefab, UnityEngine.Vector3 position)
         {
             if (!Main.Multiplayer.IsActive)
             {
@@ -448,13 +449,28 @@ namespace WOTRMultiplayer.HarmonyPatches.RandomIdGeneration
 
             try
             {
-                var seededContext = Main.Multiplayer.GetSeededContext(SeedKind.Session | SeedKind.LoadedSaveSeed | SeedKind.CombatTurnSeed);
+                var seedKind = SeedKind.Session | SeedKind.LoadedSaveSeed;
                 var baseIdentifier = $"{CommonTranspilerReplacements.GetSharedIdentifierPart()}:{unit.AssetGuid}:{unit.name}:{unit.Faction}:{prefab.name}";
                 if (Rulebook.CurrentContext?.CurrentEvent is RuleSummonUnit ruleSummonUnit)
                 {
                     baseIdentifier += $":{ruleSummonUnit.Initiator?.UniqueId}";
+                    seedKind |= SeedKind.CombatTurnSeed;
+                }
+                else
+                {
+                    // Scripted spawns of identical blueprints share every identifier component, so without
+                    // a per-instance discriminator they collapse onto the order-based collision counter,
+                    // which is not synchronized between host and client. The spawn position is a fixed,
+                    // scene-serialized value (identical on both machines) and is unique per spawn point,
+                    // so it disambiguates them deterministically. Quantize to centimeters as integers to
+                    // avoid any float-to-string drift.
+                    var px = (long)UnityEngine.Mathf.Round(position.x * 100f);
+                    var py = (long)UnityEngine.Mathf.Round(position.y * 100f);
+                    var pz = (long)UnityEngine.Mathf.Round(position.z * 100f);
+                    baseIdentifier += $":{px},{py},{pz}";
                 }
 
+                var seededContext = Main.Multiplayer.GetSeededContext(seedKind);
                 var rawIdentifier = $"{baseIdentifier}_{seededContext.Id}";
                 var id = Main.Multiplayer.ValueGenerator.GenerateUniqueId(IdType.Unit, Game.Instance.Player.GameId, rawIdentifier);
                 Main.GetLogger<EntitiesIdsPatches>().LogInformation("Unit id has been generated. RawIdentifier={RawIdentifier}, Id={Id}", rawIdentifier, id);

--- a/src/WOTRMultiplayer/Services/MultiplayerActorBase.cs
+++ b/src/WOTRMultiplayer/Services/MultiplayerActorBase.cs
@@ -674,6 +674,17 @@ namespace WOTRMultiplayer.Services
                 }
 
                 AddPlayerReadyStatus(PlayerTurnReadinessType.UnitJoinedMidCombat, Game.LocalPlayerId, unitId);
+
+                // The remote player may have already confirmed this unit before our local JoinCombat
+                // fired. In that case the unit is fully confirmed right now, so let it join immediately
+                // instead of deferring to the next turn boundary.
+                if (TryConfirmMidCombatUnit(unitId))
+                {
+                    MakeUnitTargetable(unitId, groupId);
+                    Logger.LogWarning("Unit has been allowed to join mid combat immediately on local confirmation. UnitId={UnitId}", unitId);
+                    return true;
+                }
+
                 MakeUnitUntargetable(unitId, groupId);
 
                 return false;
@@ -4142,6 +4153,15 @@ namespace WOTRMultiplayer.Services
             }
 
             AddPlayerReadyStatus(PlayerTurnReadinessType.UnitJoinedMidCombat, message.PlayerId, message.UnitId);
+
+            // Our local JoinCombat has likely already fired and is waiting; this notification may complete
+            // the all-players confirmation. If so, join the unit immediately instead of waiting for the
+            // turn to end.
+            if (TryConfirmMidCombatUnit(message.UnitId))
+            {
+                Logger.LogWarning("Mid-combat unit confirmed by all players, joining immediately. UnitId={UnitId}", message.UnitId);
+                CombatInteraction.AddUnitsToCombat([message.UnitId]);
+            }
         }
 
         private void OnNotifyRestBanterInterrupted(long receivedFrom, NotifyRestBanterInterrupted message)
@@ -4335,6 +4355,29 @@ namespace WOTRMultiplayer.Services
                         Game.Combat.ConfirmedMidCombatUnits.Add(kv.Key);
                     }
                 }
+            }
+        }
+
+        // Returns true only on the call that transitions the unit to confirmed (all synced players have
+        // acknowledged its mid-combat join), so the caller can join it immediately. Idempotent afterwards.
+        private bool TryConfirmMidCombatUnit(string unitId)
+        {
+            lock (ActionLock)
+            {
+                if (Game.Combat == null)
+                {
+                    return false;
+                }
+
+                var tracker = GetPlayerTurnReadinessTracker(PlayerTurnReadinessType.UnitJoinedMidCombat);
+                if (tracker != null
+                    && tracker.TryGetValue(unitId, out var readyPlayers)
+                    && readyPlayers.Count >= GetSyncedPlayersCount())
+                {
+                    return Game.Combat.ConfirmedMidCombatUnits.Add(unitId);
+                }
+
+                return false;
             }
         }
 


### PR DESCRIPTION
Fixes #14

## Problem
Enemies spawning mid-combat (Drezen / Defender's Heart reinforcements) could end
up untargetable and never join combat in 2-player co-op. Two independent causes:

1. The same spawned enemy got different `UniqueId`s on host vs client, so the
   mid-combat-join confirmation never reached all players and the unit stayed
   untargetable forever (and in some cases got force-excluded from combat during
   reconciliation).
2. Even once confirmed, joining was deferred to the next turn boundary, so a
   reinforcement could stand idle, visible but not in combat, for up to a full turn.

## Root cause
- `GetNewUnitUniqueId` mixed the volatile `CombatTurnSeed` into the identifier.
  For scripted (non-summon) spawns it resolves differently per machine, and for
  multiple identical blueprints the only remaining distinguisher was the
  order-based collision counter in `DeterministicValueGenerator.GenerateUniqueId`,
  which isn't synchronized between peers. Result: host and client computed
  different ids for the same physical unit.
- Confirmed mid-combat units were only added to combat in `OnTurnEnded`, so the
  join waited for the entire current turn to finish even though both players had
  already acknowledged the unit within a fraction of a second.

## Fix
- **Deterministic spawn ids:** drop `CombatTurnSeed` for non-summon spawns and
  instead disambiguate identical blueprints by their quantized spawn position,
  which is a scene-serialized value identical on both peers and unique per spawn
  point. `CombatTurnSeed` is kept only for `RuleSummonUnit` summons (where it is
  deterministic, since summons happen on a synchronized turn).
- **Immediate join:** join confirmed mid-combat units as soon as all synced
  players acknowledge them, instead of deferring to the next turn boundary. The
  turn-boundary add is kept as an idempotent fallback.

## Testing
- Builds clean; unit tests pass (101/101).
- Verified live in a 2-player session in the Drezen citadel encounter: the three
  reinforcement Vrocks now get matching ids on both host and client, become
  targetable, and join combat immediately instead of staying untargetable.